### PR TITLE
Wrong limit on no. of phi bins

### DIFF
--- a/StRoot/StFastSimulator/StFastSimUtilities.cxx
+++ b/StRoot/StFastSimulator/StFastSimUtilities.cxx
@@ -228,7 +228,7 @@ int StFastSimUtilities::getVzIndex(double const Vz) const
 
 int StFastSimUtilities::getPhiIndex(double const Phi) const
 {
-   for (int i = 0; i < nPtBins; i++)
+   for (int i = 0; i < nPhis; i++)
    {
       if ((Phi >= PhiEdge[i]) && (Phi < PhiEdge[i + 1]))
          return i;


### PR DESCRIPTION
Should not be an issue in current work since nPtBins > nPhis, however should be fixed
